### PR TITLE
ISS passes can be predicted when specifying grid square

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ HamTheMan (htm) is a Discord bot for various ham radio related things, including
 - Python: Python 3.10 or higher
 - Discord: `pip3 install discord.py` OR `pip3 install -U discord.py` OR `python3 -m "pip" install discord.py`
 - Requests: `pip3 install requests`
+- ISS pass info: `pip3 install pytz maidenhead TimezoneFinder`
 
 ### API Keys
 
@@ -28,6 +29,7 @@ HamTheMan (htm) is a Discord bot for various ham radio related things, including
   - `hamqth`
     - `username` Your callsign
     - `password` Your HamQTH password
+  - `n2yo` Your API key from N2YO.com
   - `oofs`: No need to touch this.
 
 ## Running HamTheMan

--- a/config_default.json
+++ b/config_default.json
@@ -6,5 +6,6 @@
         "username": "put username here",
         "password": "put password here"
     },
+    "n2yo": "put N2YO.com API key here",
     "oofs": 0
 }

--- a/hamtheman.py
+++ b/hamtheman.py
@@ -26,7 +26,8 @@ class HamTheManBot(commands.Bot):
         'modules.lookup',
         'modules.misc',
         'modules.morse',
-        'modules.reactions']
+        'modules.reactions',
+        'modules.iss']
     
     config = {}
     start_time = time.time()

--- a/modules/iss.py
+++ b/modules/iss.py
@@ -1,0 +1,82 @@
+import discord
+import json, urllib.request, pytz, time
+import maidenhead as mh
+from discord.ext import commands
+from datetime import datetime
+from timezonefinder import TimezoneFinder
+
+def convert_utc_to_local(utc_timestamp, timezone_str):
+    if timezone_str:
+        timezone = pytz.timezone(timezone_str)
+        utc_datetime = datetime.utcfromtimestamp(utc_timestamp)
+        local_datetime = utc_datetime.replace(tzinfo=pytz.utc).astimezone(timezone)
+        return local_datetime.strftime("%I:%M%p %Z")
+    else:
+        return None
+
+class IssCog(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+        self.embed_Service = bot.get_cog('EmbedCog')
+        self.n2yoapi = bot.config['n2yo']
+
+    @commands.command()
+    async def iss(self, ctx, *, text: str = None):
+        starttime = int(time.time())
+        if text is None:
+            await ctx.send("Usage: htm iss <gridsquare>")
+            return
+        elif self.n2yoapi == "0":
+            await ctx.send("Please ask the host of this bot to sign up for API access at N2YO.com")
+            return      
+        else:
+            grid = text
+        try:
+            lat = mh.to_location(grid)[0]
+            lon = mh.to_location(grid)[1]
+            tz_finder = TimezoneFinder()
+            timezone_str = tz_finder.timezone_at(lng=lon, lat=lat)
+        except:
+            await ctx.send("Invalid grid square")
+            return
+        data = urllib.request.urlopen("https://api.n2yo.com/rest/v1/satellite/radiopasses/25544/" + str(lat) + "/" + str(lon) + "/150/1/5/&apiKey=" + self.n2yoapi + "").read()
+        ISS = json.loads(data)
+
+        passlist = []
+
+        # This takes a three letter compass point (NNW, ESE) and makes it just two. I don't need it that precise!        
+        def compasstrim(c):
+            if (len(c) == 3):
+                return c[1:]
+            elif (len(c) == 1):
+                return c.rjust(2, ' ')
+            elif (len(c) == 2):
+                return c
+
+        for x in ISS['passes']:
+            nicetime = convert_utc_to_local(x['startUTC'], timezone_str)
+            if (nicetime[0] == '0'):
+                nicetime = nicetime.lstrip('0')
+                nicetime = " " + nicetime
+            if (len(nicetime) == 6):
+                nicetime = ' ' + nicetime
+            if (len(str(round(x['maxEl']))) == 2):
+                maxel = ' ' + str(round(x['maxEl']))
+            elif (len(str(round(x['maxEl']))) == 1):
+                maxel = '  ' + str(round(x['maxEl']))
+            passlist.append('| ' + nicetime  + ' ' + compasstrim(x['startAzCompass']) + ' ->' + maxel + "°" + ' -> ' + compasstrim(x['endAzCompass']) + ' \n')
+        separator = ', '
+        items_as_strings = [str(item) for item in passlist]
+        passstring = separator.join(items_as_strings)
+        newpassstring = passstring.replace(separator, '')
+        stoptime = int(time.time()) - starttime
+        await ctx.send(embed=self.embed_Service
+            .generate(
+                title="ISS Passes for " + grid.upper(),
+                description=f"```\n{newpassstring}\n```",
+                footer="Processing time: " + str(stoptime) + " sec"
+            )
+        )
+
+async def setup(bot):
+        await bot.add_cog(IssCog(bot))

--- a/modules/misc.py
+++ b/modules/misc.py
@@ -112,6 +112,7 @@ help_message = ('**Core commands**\n'
                 ', callook.info)\n'
                 '\t**morse [message]:** Translates a message into morse code '
                 '(use quotes)\n'
+                '\t**iss [grid square]:** Shows ISS pass info. Takes several seconds.\n'
                 '\n**#someta**\n'
                 '\t**about:** About the bot\n'
                 '\t**uptime:** Bot uptime\n'
@@ -121,7 +122,6 @@ help_message = ('**Core commands**\n'
                 '\t**oofs:** Counts all oofs in all servers since last '
                 'reboot\n'
                 '\n**This bot is also responsible for the oofs and bonks**')
-
 
 htm_about = ('**Author**\n'
              '\tBen Johnson, AB3NJ\n'


### PR DESCRIPTION
I have added a new cog called ISS that will allow a user to grab the next 24 hours of ISS pass predictions based on the grid square specified in the command.

Usage:
htm iss <grid square 4-8 char>

Example:
htm iss FN10
htm iss FN10ua
htm iss FM19xc18

upper/lower case is just fine.

Based on the hardware used, the processing time may take a bit when converting lat/lon to time zone. For example, on my pi2, it takes 8 seconds. A pi4 takes 3 seconds. My Windows PC is instant. 

Disclaimer: I am just a hobbyist and do not work as a programmer. I think I copied over all the needed files I've changed. This is currently running on a few discord servers with no issues. I greatly appreciate any and all feedback. 